### PR TITLE
Add support for Visual Studio themes

### DIFF
--- a/OpenCover.UI/OpenCover.UI.VS2013.csproj
+++ b/OpenCover.UI/OpenCover.UI.VS2013.csproj
@@ -89,6 +89,8 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.11.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
+    <Reference Include="PresentationFramework.Aero" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -277,6 +279,10 @@
     <Content Include="Resources\Package.ico" />
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Views\Style.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Views\BusyIndicator.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/OpenCover.UI/OpenCover.UI.csproj
+++ b/OpenCover.UI/OpenCover.UI.csproj
@@ -89,6 +89,8 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.11.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
+    <Reference Include="PresentationFramework.Aero" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -277,6 +279,10 @@
     <Content Include="Resources\Package.ico" />
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Views\Style.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Views\BusyIndicator.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/OpenCover.UI/Views/CodeCoverageResultsControl.xaml
+++ b/OpenCover.UI/Views/CodeCoverageResultsControl.xaml
@@ -7,15 +7,29 @@
 			 xmlns:sd="http://icsharpcode.net/sharpdevelop/treeview"
 			 xmlns:c="clr-namespace:OpenCover.UI.Converters"
 			 xmlns:v="clr-namespace:OpenCover.UI.Views"
+             xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.11.0"
+             xmlns:win="clr-namespace:System.Windows;assembly=PresentationFramework"
 			 mc:Ignorable="d"
 			 d:DesignHeight="300" d:DesignWidth="1000"
 			 Name="CodeCoverageToolWindow">
+    
 	<UserControl.Resources>
-		<c:WidthConverter x:Key="widthConverter"/>
-		<c:BooleanToVisibilityConverter x:Key="booleanToVisibilityConverter"/>
-		<c:NotBooleanToVisibilityConverter x:Key="notBooleanToVisibilityConverter"/>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Style.xaml" />
+                <ResourceDictionary>
+                    <c:WidthConverter x:Key="widthConverter"/>
+                    <c:BooleanToVisibilityConverter x:Key="booleanToVisibilityConverter"/>
+                    <c:NotBooleanToVisibilityConverter x:Key="notBooleanToVisibilityConverter"/>
+        </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
 	</UserControl.Resources>
-	<Grid>
+    <UserControl.Style>
+        <win:StaticResource ResourceKey="VSUserControlStyle"/>
+    </UserControl.Style>
+
+    <Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition />
 		</Grid.RowDefinitions>
@@ -27,11 +41,12 @@
 			<Canvas Grid.Row="0" Width="50" Height="50">
 				<v:BusyIndicator Visibility="{Binding IsLoading, Converter={StaticResource booleanToVisibilityConverter}, ConverterParameter=IsLoading}" />
 			</Canvas>
-			<TextBlock Grid.Row="1" FontWeight="Bold">Please wait while we collect coverage results</TextBlock>
+            <TextBlock Grid.Row="1">Please wait while we collect coverage results</TextBlock>
 		</Grid>
-		<sd:SharpTreeView x:Name="CodeCoverageResultsTreeView" ShowRoot="False" ShowAlternation="True" 
+		<sd:SharpTreeView x:Name="CodeCoverageResultsTreeView"
 						  MouseDoubleClick="TreeViewItemDoubleClicked" Grid.Row="0" 
-						  Visibility="{Binding IsLoading, Converter={StaticResource notBooleanToVisibilityConverter}, ConverterParameter=IsLoading}">
+						  Visibility="{Binding IsLoading, Converter={StaticResource notBooleanToVisibilityConverter}, ConverterParameter=IsLoading}"
+                          BorderBrush="Transparent" BorderThickness="0">
 			<ListView.View>
 				<sd:SharpGridView>
 					<GridView.Columns>

--- a/OpenCover.UI/Views/Style.xaml
+++ b/OpenCover.UI/Views/Style.xaml
@@ -1,0 +1,116 @@
+﻿<!--
+    info about styling and templating ListView (and GridView) :
+    https://msdn.microsoft.com/en-us/library/ms788747(v=vs.110).aspx
+    -->
+
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.11.0"
+                    xmlns:sd="http://icsharpcode.net/sharpdevelop/treeview"
+                    xmlns:aero="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero">
+
+    <Style x:Key="VSUserControlStyle" TargetType="UserControl">
+        <Setter Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBackgroundBrushKey}}"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+    </Style>
+    
+    <Style TargetType="sd:SharpTreeView">
+        <Setter Property="ShowRoot" Value="False"/>
+        <Setter Property="ShowAlternation" Value="False"/>
+        <Setter Property="ShowLines" Value="False"/>
+        <Setter Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBackgroundBrushKey}}"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+        <Setter Property="ListView.BorderBrush" Value="Transparent"/>
+        <Setter Property="ListView.Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ListView}">
+                    <aero:ListBoxChrome Name="Bd"
+                                     BorderThickness="{TemplateBinding BorderThickness}"
+                                     BorderBrush="{TemplateBinding BorderBrush}"
+                                     Background="{TemplateBinding Background}"
+                                     RenderFocused="False"
+                                     SnapsToDevicePixels="true">
+                        <ScrollViewer Style="{DynamicResource {x:Static GridView.GridViewScrollViewerStyleKey}}"
+                                  Padding="{TemplateBinding Padding}">
+                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                        </ScrollViewer>
+                    </aero:ListBoxChrome>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsGrouping"
+                             Value="true">
+                            <Setter Property="ScrollViewer.CanContentScroll"
+                                Value="false"/>
+                        </Trigger>
+                        
+                        <Trigger Property="IsEnabled"
+                             Value="false">
+                            <Setter TargetName="Bd"
+                                Property="Background"
+                                Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+                        </Trigger>
+                        
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
+    <Style TargetType="GridSplitter">
+        <Setter Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.PanelSeparatorBrushKey}}"/>
+    </Style>
+
+    <Style TargetType="GridViewColumnHeader">
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+
+        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:HeaderColors.SeparatorLineBrushKey}}"/>
+        
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:HeaderColors.DefaultTextBrushKey}}"/>
+        <Setter Property="Background" Value="{DynamicResource {x:Static vsui:HeaderColors.DefaultBrushKey}}"/>
+
+        <Setter Property="Padding" Value="6,2,2,2" />
+
+        <Setter Property="Template" >
+            <Setter.Value>
+                <ControlTemplate TargetType="GridViewColumnHeader">
+                    <Grid>
+                        <Border x:Name="HeaderBorder"
+                                BorderThickness="0,0,0,1"                 
+                                BorderBrush="{TemplateBinding BorderBrush}" 
+                                Background="{TemplateBinding Background}"
+                                Padding="{TemplateBinding Padding}" >
+                            <ContentPresenter x:Name="HeaderContent" 
+                                  RecognizesAccessKey="True"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                        </Border>
+
+                        <Thumb x:Name="PART_HeaderGripper" HorizontalAlignment="Right" Margin="0,0,-2,0" Width="6"
+                               Background="{DynamicResource {x:Static vsui:HeaderColors.SeparatorLineBrushKey}}">
+                            <Thumb.Template>
+                                <ControlTemplate>
+                                    <Border Background="Transparent" Padding="{TemplateBinding Padding}">
+                                        <Rectangle HorizontalAlignment="Center" Width="1" Fill="{TemplateBinding Background}"/>
+                                    </Border>
+                                </ControlTemplate>
+                            </Thumb.Template>
+                        </Thumb>
+
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:HeaderColors.MouseOverTextBrushKey}}"/>
+                            <Setter Property="Background" Value="{DynamicResource {x:Static vsui:HeaderColors.MouseOverBrushKey}}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="true">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:HeaderColors.MouseDownTextBrushKey}}"/>
+                            <Setter Property="Background" Value="{DynamicResource {x:Static vsui:HeaderColors.MouseDownBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/OpenCover.UI/Views/TestExplorerControl.xaml
+++ b/OpenCover.UI/Views/TestExplorerControl.xaml
@@ -9,43 +9,52 @@
 			 xmlns:local="clr-namespace:OpenCover.UI.Model.Test"
 			 xmlns:test="clr-namespace:OpenCover.UI.Model"
 			 xmlns:v="clr-namespace:OpenCover.UI.Views"
+             xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.11.0"
+             xmlns:win="clr-namespace:System.Windows;assembly=PresentationFramework"
 			 mc:Ignorable="d" 
 			 d:DesignHeight="300" d:DesignWidth="300"
 			 x:Name="testExplorerControl">
+    
 	<UserControl.Resources>
-		<c:WidthConverter x:Key="widthConverter"/>
-		<c:TestExecutionResultStatusToIconConverter x:Key="testExecutionResultStatusToIconConverter"/>
-		<c:NullToVisibilityConverter x:Key="nullToVisibilityConverter" />
-		<SolidColorBrush x:Key="gridSplitterColor">
-			<SolidColorBrush.Color>
-				<Color A="255" R="41" G="57" B="85"/>
-			</SolidColorBrush.Color>
-		</SolidColorBrush>
-	</UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Style.xaml" />
+                <ResourceDictionary>
+                    <c:WidthConverter x:Key="widthConverter"/>
+                    <c:TestExecutionResultStatusToIconConverter x:Key="testExecutionResultStatusToIconConverter"/>
+                    <c:NullToVisibilityConverter x:Key="nullToVisibilityConverter" />
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <UserControl.Style>
+        <win:StaticResource ResourceKey="VSUserControlStyle"/>
+    </UserControl.Style>
+    
 	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="80*" />
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="20*" />
 		</Grid.RowDefinitions>
-		<sd:SharpTreeView x:Name="TestsTreeView" ShowRoot="False" ShowAlternation="False" ShowRootExpander="False" HorizontalAlignment="Stretch"
-						  Grid.Row="0" Foreground="Black" ShowLines="False" SelectionChanged="TestSelectionChanged">
-			<ListView.View>
-				<sd:SharpGridView>
-					<GridView.Columns>
-						<GridViewColumn>
-							<GridViewColumn.CellTemplate>
-								<DataTemplate>
-									<sd:SharpTreeNodeView MouseRightButtonDown="Grid_MouseRightButtonDown" Name="method"
+        <sd:SharpTreeView x:Name="TestsTreeView" ShowRootExpander="False" HorizontalAlignment="Stretch"
+						  Grid.Row="0" SelectionChanged="TestSelectionChanged">
+            <ListView.View>
+                <sd:SharpGridView>
+                    <GridView.Columns>
+                        <GridViewColumn>
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <sd:SharpTreeNodeView MouseRightButtonDown="Grid_MouseRightButtonDown" Name="method"
 															Margin="0 2 0 2" />
-								</DataTemplate>
-							</GridViewColumn.CellTemplate>
-						</GridViewColumn>
-					</GridView.Columns>
-				</sd:SharpGridView>
-			</ListView.View>
-		</sd:SharpTreeView>
-		<GridSplitter Grid.Row="1" Grid.RowSpan="1" ResizeDirection="Rows" Width="Auto" Height="3" HorizontalAlignment="Stretch" Margin="0" Background="{StaticResource gridSplitterColor}" />
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                    </GridView.Columns>
+                </sd:SharpGridView>
+            </ListView.View>
+        </sd:SharpTreeView>
+        <GridSplitter Grid.Row="1" Grid.RowSpan="1" ResizeDirection="Rows" Width="Auto" Height="3" HorizontalAlignment="Stretch" Margin="0" />
 		<StackPanel Grid.Row="2" HorizontalAlignment="Stretch" Margin="0" Orientation="Vertical">
 			<TextBlock Text="{Binding TestResult.Caption}" Margin="0,0,0,4" FontWeight="Bold" FontSize="14"/>
 			<ItemsControl ItemsSource="{Binding TestResult.ExecutionStatus}">
@@ -61,16 +70,24 @@
 				</ItemsControl.ItemTemplate>
 			</ItemsControl>
 			<v:TestResults DataContext="{Binding TestResult.Result}" />
-			<TreeView DataContext="{Binding TestResult.Result}" HorizontalAlignment="Stretch" Visibility="{Binding Path=TestCases, Converter={StaticResource nullToVisibilityConverter}}"
-				MaxHeight="300" BorderThickness="0">
-				<TreeViewItem Header="Test Cases" ItemsSource="{Binding TestCases}" Visibility="{Binding Converter={StaticResource nullToVisibilityConverter}}">
-					<TreeViewItem.ItemTemplate>
-						<DataTemplate>
-							<v:TestResults />
-						</DataTemplate>
-					</TreeViewItem.ItemTemplate>
-				</TreeViewItem>
-			</TreeView>
-		</StackPanel>
+            <Border
+                    Visibility="{Binding Path=TestResult, Converter={StaticResource nullToVisibilityConverter}}">
+                <Border DataContext="{Binding TestResult}" 
+                    Visibility="{Binding Path=Result, Converter={StaticResource nullToVisibilityConverter}}">
+                    <TreeView DataContext="{Binding Result}" HorizontalAlignment="Stretch" 
+                          Visibility="{Binding Path=TestCases, Converter={StaticResource nullToVisibilityConverter}}"
+				          MaxHeight="300" BorderThickness="0" BorderBrush="Transparent">
+                        <TreeViewItem Header="Test Cases" ItemsSource="{Binding TestCases}" 
+                                  Visibility="{Binding Converter={StaticResource nullToVisibilityConverter}}">
+                            <TreeViewItem.ItemTemplate>
+                                <DataTemplate>
+                                    <v:TestResults />
+                                </DataTemplate>
+                            </TreeViewItem.ItemTemplate>
+                        </TreeViewItem>
+                    </TreeView>
+                </Border>
+            </Border>
+        </StackPanel>
 	</Grid>
 </UserControl>

--- a/OpenCover.UI/Views/TestResults.xaml
+++ b/OpenCover.UI/Views/TestResults.xaml
@@ -4,24 +4,38 @@
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
 			 xmlns:c="clr-namespace:OpenCover.UI.Converters"
+             xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.11.0"
+             xmlns:win="clr-namespace:System.Windows;assembly=PresentationFramework"
 			 mc:Ignorable="d" 
 			 d:DesignHeight="300" d:DesignWidth="300"
 			 x:Name="testResults">
-	<UserControl.Resources>
-		<c:WidthConverter x:Key="widthConverter"/>
-		<c:TestExecutionResultStatusToIconConverter x:Key="testExecutionResultStatusToIconConverter"/>
-		<c:NullToVisibilityConverter x:Key="nullToVisibilityConverter" />
-	</UserControl.Resources>
-	<StackPanel Orientation="Vertical" x:Name="wrapper" HorizontalAlignment="Stretch"
-				MaxWidth="{Binding ActualWidth, ElementName=testExplorerControl}" Margin="0, 2">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Style.xaml" />
+                <ResourceDictionary>
+                    <c:WidthConverter x:Key="widthConverter"/>
+                    <c:TestExecutionResultStatusToIconConverter x:Key="testExecutionResultStatusToIconConverter"/>
+                    <c:NullToVisibilityConverter x:Key="nullToVisibilityConverter" />
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <UserControl.Style>
+        <win:StaticResource ResourceKey="VSUserControlStyle"/>
+    </UserControl.Style>
+
+    <StackPanel Orientation="Vertical" x:Name="wrapper" HorizontalAlignment="Stretch"
+				MaxWidth="{Binding ActualWidth, ElementName=testExplorerControl}" Margin="0, 2" >
 		<StackPanel Orientation="Horizontal" Margin="0,0,0,2">
 			<Image Source="{Binding Path=Status, Converter={StaticResource testExecutionResultStatusToIconConverter}}" Margin="0,0,2,0" />
 			<TextBlock Text="{Binding Status}" FontWeight="Bold" Margin="1,0"/>
 		</StackPanel>
-		<StackPanel Orientation="Horizontal" Margin="0,0,0,2" DataContext="{Binding ExecutionTime}" Visibility="{Binding Converter={StaticResource nullToVisibilityConverter}}">
+		<StackPanel Orientation="Horizontal" Margin="0,0,0,2" DataContext="{Binding ExecutionTime}" 
+                    Visibility="{Binding Converter={StaticResource nullToVisibilityConverter}}">
 			<TextBlock Text="Elapsed time - " FontWeight="Bold"/>
-			<TextBlock Text="{Binding}"/>
-		</StackPanel>
+            <TextBlock Text="{Binding}"/>
+        </StackPanel>
 		<StackPanel Orientation="Vertical" Margin="0,0,0,2" DataContext="{Binding FailureMessages}"
 					Visibility="{Binding Converter={StaticResource nullToVisibilityConverter}}" HorizontalAlignment="Stretch"
 					Width="{Binding ActualWidth, ElementName=testExplorerControl, Converter={StaticResource widthConverter}, ConverterParameter=80}">


### PR DESCRIPTION
Added support for the Visual Studio themes, fixes #28

Example screens with these changes:
*Light theme*
![image](https://cloud.githubusercontent.com/assets/1618378/6220714/f68e55d6-b639-11e4-8e04-0c0c95e7bd01.png)
![image](https://cloud.githubusercontent.com/assets/1618378/6220724/087b9498-b63a-11e4-8f0f-c5538b8adbd1.png)
*Dark theme*
![image](https://cloud.githubusercontent.com/assets/1618378/6220730/2b42bc86-b63a-11e4-92f7-5bcf9ee5576b.png)
![image](https://cloud.githubusercontent.com/assets/1618378/6220733/3c252a5c-b63a-11e4-94f4-901c06480e54.png)
*Blue theme*
![image](https://cloud.githubusercontent.com/assets/1618378/6220738/56333f42-b63a-11e4-9647-7a64e7b0f19d.png)
![image](https://cloud.githubusercontent.com/assets/1618378/6220745/66ff8aa6-b63a-11e4-96e2-304e9eab48a2.png)
