### PR TITLE
Enable plugin debugging

### DIFF
--- a/OpenCover.UI/OpenCover.UI.VS2013.csproj
+++ b/OpenCover.UI/OpenCover.UI.VS2013.csproj
@@ -26,6 +26,9 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <StartAction>Program</StartAction>
+    <StartProgram>$(ProgramFiles)\Microsoft Visual Studio 12.0\Common7\IDE\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/OpenCover.UI/OpenCover.UI.csproj
+++ b/OpenCover.UI/OpenCover.UI.csproj
@@ -26,6 +26,9 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <StartAction>Program</StartAction>
+    <StartProgram>$(ProgramFiles)\Microsoft Visual Studio 11.0\Common7\IDE\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>


### PR DESCRIPTION
Configured the projects to allow us to debug the plugin from inside visual studio.

To debug the plugin, the following steps can be used: 
- set the OpenCover.UI.VS2013 project as the startup project
- build & run the solution/project
- this will open a new Visual Studio instance, with the newly build version of the plugin (any installed version of the plugin will not be affected by this: the new VS instance will run the plugin in some kind of sandboxed environment, see also https://msdn.microsoft.com/en-us/library/bb166560.aspx )
- open a solution you want to test-drive the plugin with
- any breakpoint set in the OpenCover.UI project will be hit

This should allow us to more easily debug issues (and develop new features) in the future, and makes sure the Visual Studio environment doesn't get corrupted if something goes wrong in the plugin