### PR TITLE
Goto test from testexplorer

### DIFF
--- a/OpenCover.UI.Tests/OpenCover.UI.Tests.csproj
+++ b/OpenCover.UI.Tests/OpenCover.UI.Tests.csproj
@@ -82,7 +82,9 @@
       <Name>OpenCover.UI.Framework</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/OpenCover.UI/Views/TestExplorerControl.xaml
+++ b/OpenCover.UI/Views/TestExplorerControl.xaml
@@ -38,7 +38,7 @@
 			<RowDefinition Height="20*" />
 		</Grid.RowDefinitions>
         <sd:SharpTreeView x:Name="TestsTreeView" ShowRootExpander="False" HorizontalAlignment="Stretch"
-						  Grid.Row="0" SelectionChanged="TestSelectionChanged">
+						  Grid.Row="0" SelectionChanged="TestSelectionChanged" MouseDoubleClick="TestsTreeView_MouseDoubleClick">
             <ListView.View>
                 <sd:SharpGridView>
                     <GridView.Columns>

--- a/OpenCover.UI/Views/TestExplorerControl.xaml.cs
+++ b/OpenCover.UI/Views/TestExplorerControl.xaml.cs
@@ -218,6 +218,28 @@ namespace OpenCover.UI.Views
 				PropertyChanged(this, new PropertyChangedEventArgs(property));
 			}
 		}
+        
+        private void TestsTreeView_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            try
+            {
+                var treeView = sender as ICSharpCode.TreeView.SharpTreeView;
+                var selectedItem = treeView.SelectedItem;
+
+                var testMethod = selectedItem as TestMethod;
+                if (testMethod != null)
+                {
+                    var fullyQualifiedMethodName = testMethod.FullyQualifiedName;
+                    IDEHelper.WriteToOutputWindow("Navigating to test method: {0}", fullyQualifiedMethodName);
+
+                    IDEHelper.OpenFileByFullyQualifiedMethodName(fullyQualifiedMethodName);
+                }
+            }
+            catch(Exception exception)
+            {
+                IDEHelper.WriteToOutputWindow(exception.Message);
+            }
+        }
 	}
 
 	public class TestResultsViewModel


### PR DESCRIPTION
Enables support to open tests from the OpenCoverUI testexplorer
Fixes #13 

Small note: because of issue #25 some methods are not opened yet (only for very specific cases: this is because the tests in the base classes are not discovered correctly yet: they are shown in the TestExplorer as being tests from the base class, while they should be listed as testmethods from the actual (inheriting) class.)