### PR TITLE
Fix: MSTestExecutor.GetTestResult() throws exception if no duration attr...

### DIFF
--- a/OpenCover.UI/Processors/MSTestExecutor.cs
+++ b/OpenCover.UI/Processors/MSTestExecutor.cs
@@ -174,9 +174,12 @@ namespace OpenCover.UI.Processors
 			var errorMessage = errorInfo != null ? GetElementValue(errorInfo, "Message", ns) : null;
 			var stackTrace = errorInfo != null ? GetElementValue(errorInfo, "StackTrace", ns) : null;
 
+			var durationAttributeValue = GetAttributeValue(ut, "duration");
+			Decimal? executionTime = durationAttributeValue != null ? (Decimal)TimeSpan.Parse(durationAttributeValue).TotalSeconds : (Decimal?) null;
+
 			return new TestResult(null,
 								GetTestExecutionStatus(GetAttributeValue(ut, "outcome")),
-								(Decimal)TimeSpan.Parse(GetAttributeValue(ut, "duration")).TotalSeconds,
+								executionTime,
 								errorMessage,
 								stackTrace,
 								null);


### PR DESCRIPTION
...ibute exists.

I was having the issue
"Cover with OpenCover" disabled in Test Explorer - mentioned on 
https://visualstudiogallery.msdn.microsoft.com/6950a046-8919-4935-8542-c6f37956f688/view/Discussions

The issue for me, as far as I could tell was that if I started VS, opened test explorer, viewed by project, ran a single test, then I could then run the single test again, but not a third time.

It seemed that on the second run one of the `<UnitTestResult>` elements had no `duration` attribute, causing `TimeSpan.Parse(null)`  - it was marked `outcome="NotExecuted"`:


	<UnitTestResult executionId="fd842622-fbb2-4767-841d-ac0cdc32fea3" testId="d016ac62-e38c-d43c-8df1-c76d40f31c61" testName="PushPackageTrigger_Serialize_Deserialize" computerName="MCSAJ07" startTime="2015-04-08T23:49:11.9108766+01:00" endTime="2015-04-08T23:49:11.9108766+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fd842622-fbb2-4767-841d-ac0cdc32fea3" />
    
I fixed this by checking for the `duration` attribute - if it doesn't exist, then skip trying to parse the missing attribute, instead passing null into the `TestResult` constructor for `executionTime` 