### PR TITLE
Corrected crash of extensions when modifying a covered file

### DIFF
--- a/OpenCover.UI/Glyphs/LineCoverageGlyphFactory.cs
+++ b/OpenCover.UI/Glyphs/LineCoverageGlyphFactory.cs
@@ -156,7 +156,8 @@ namespace OpenCover.UI.Glyphs
         /// <returns></returns>
         public static IEnumerable<SnapshotSpan> GetSpansForLine(ITextViewLine line, IEnumerable<SnapshotSpan> spanContainer)
         {
-            return spanContainer.Where(s => (s.Start >= line.Start && s.Start <= line.End) || (s.Start < line.Start && s.End >= line.Start));
+            return spanContainer.Where(s => s.Snapshot.Version == line.Snapshot.Version)
+                .Where(s => (s.Start >= line.Start && s.Start <= line.End) || (s.Start < line.Start && s.End >= line.Start));
         }    
 
         /// <summary>


### PR DESCRIPTION
Operating across snapshot versions was causing the extension to crash.
This ensures only corresponding versions are used to retrieve spans.

cherry picked this fix from the commit by @joshlrogers