### PR TITLE
Handle missing ToolWindow

### DIFF
--- a/OpenCover.UI/Commands/TestsExplorerToolbarCommands.cs
+++ b/OpenCover.UI/Commands/TestsExplorerToolbarCommands.cs
@@ -133,7 +133,11 @@ namespace OpenCover.UI.Commands
 					break;
 			}
 
-			OpenCoverUIPackage.Instance.ToolWindows.OfType<TestExplorerToolWindow>().First().TestExplorerControl.ChangeGroupBy(CurrentSelectedGroupBy);
+			var testExplorerToolWindow = OpenCoverUIPackage.Instance.ToolWindows.OfType<TestExplorerToolWindow>().FirstOrDefault();
+			if (testExplorerToolWindow != null)
+			{
+				testExplorerToolWindow.TestExplorerControl.ChangeGroupBy(CurrentSelectedGroupBy);
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
This caused an error message to appear when no tests are present in an opened solution
Fixes #75