### PR TITLE
Optimize nunit discovery

### DIFF
--- a/OpenCover.UI.TestDiscoverer/DiscovererBase.cs
+++ b/OpenCover.UI.TestDiscoverer/DiscovererBase.cs
@@ -100,5 +100,24 @@ namespace OpenCover.UI.TestDiscoverer
                 }
             }
         }
+        
+                /// <summary>
+        /// Determines whether the assembly has a reference to the NUnit library.
+        /// </summary>
+        /// <param name="assembly">Assembly to check.</param>
+        protected static bool AssemblyHasReferenceTo(AssemblyDefinition assembly, string referenceName)
+        {
+            bool hasNUnitReference = false;
+
+            foreach (var anrRef in assembly.MainModule.AssemblyReferences)
+            {
+                if (string.Equals(anrRef.Name, referenceName, StringComparison.CurrentCultureIgnoreCase))
+                {
+                    hasNUnitReference = true;
+                    break;
+                }
+            }
+            return hasNUnitReference;
+        }
     }
 }

--- a/OpenCover.UI.TestDiscoverer/NUnit/NUnitDiscoverer.cs
+++ b/OpenCover.UI.TestDiscoverer/NUnit/NUnitDiscoverer.cs
@@ -34,6 +34,13 @@ namespace OpenCover.UI.TestDiscoverer.NUnit
         /// <returns>Tests in the Assembly</returns>
         protected override List<TestClass> DiscoverTestsInAssembly(string dllPath, AssemblyDefinition assembly)
         {
+            bool hasNUnitReference = AssemblyHasReferenceTo(assembly, "nunit.framework");
+
+            if (!hasNUnitReference)
+            {
+                return new List<TestClass>();
+            }
+            
             var classes = new List<TestClass>();
             foreach (var type in assembly.MainModule.Types)
             {


### PR DESCRIPTION
Avoid scanning assemblies that don't even reference NUnit