### PR TITLE
Support for NUnit 3.X

### DIFF
--- a/OpenCover.UI/Processors/NUnitTestExecutor.cs
+++ b/OpenCover.UI/Processors/NUnitTestExecutor.cs
@@ -50,12 +50,22 @@ namespace OpenCover.UI.Processors
 			_testResultsFile = Path.Combine(_currentWorkingDirectory.FullName, String.Format("{0}.xml", fileFormat));
 			_runListFile = Path.Combine(_currentWorkingDirectory.FullName, String.Format("{0}.txt", fileFormat));
 
-			_commandLineArguments = String.Format(CommandlineStringFormat,
-													_nUnitPath,
-													String.Format("{0} /runlist=\\\"{1}\\\" /nologo /noshadow /result=\\\"{2}\\\"", dllPaths, _runListFile, _testResultsFile),
-													_openCoverResultsFile);
+            if (Path.GetFileName(_nUnitPath) == "nunit3-console.exe")
+            {
+                _commandLineArguments = String.Format(CommandlineStringFormat,
+                                        _nUnitPath,
+                                        String.Format("{0} --testlist=\\\"{1}\\\" --noheader --result=\\\"{2}\\\";format=nunit2", dllPaths, _runListFile, _testResultsFile),
+                                        _openCoverResultsFile);
+            }
+            else
+            {
+                _commandLineArguments = String.Format(CommandlineStringFormat,
+                                                    _nUnitPath,
+                                                    String.Format("{0} /runlist=\\\"{1}\\\" /nologo /noshadow /result=\\\"{2}\\\"", dllPaths, _runListFile, _testResultsFile),
+                                                    _openCoverResultsFile);
+            }
 
-			CreateRunListFile();
+            CreateRunListFile();
 		}
 
 		/// <summary>

--- a/OpenCover.UI/Processors/NUnitTestExecutor.cs
+++ b/OpenCover.UI/Processors/NUnitTestExecutor.cs
@@ -50,22 +50,22 @@ namespace OpenCover.UI.Processors
 			_testResultsFile = Path.Combine(_currentWorkingDirectory.FullName, String.Format("{0}.xml", fileFormat));
 			_runListFile = Path.Combine(_currentWorkingDirectory.FullName, String.Format("{0}.txt", fileFormat));
 
-            if (Path.GetFileName(_nUnitPath) == "nunit3-console.exe")
-            {
-                _commandLineArguments = String.Format(CommandlineStringFormat,
-                                        _nUnitPath,
-                                        String.Format("{0} --testlist=\\\"{1}\\\" --noheader --result=\\\"{2}\\\";format=nunit2", dllPaths, _runListFile, _testResultsFile),
-                                        _openCoverResultsFile);
-            }
-            else
-            {
-                _commandLineArguments = String.Format(CommandlineStringFormat,
-                                                    _nUnitPath,
-                                                    String.Format("{0} /runlist=\\\"{1}\\\" /nologo /noshadow /result=\\\"{2}\\\"", dllPaths, _runListFile, _testResultsFile),
-                                                    _openCoverResultsFile);
-            }
+			if (Path.GetFileName(_nUnitPath) == "nunit3-console.exe")
+			{
+				_commandLineArguments = String.Format(CommandlineStringFormat,
+										_nUnitPath,
+										String.Format("{0} --testlist=\\\"{1}\\\" --noheader --result=\\\"{2}\\\";format=nunit2", dllPaths, _runListFile, _testResultsFile),
+										_openCoverResultsFile);
+			}
+			else
+			{
+				_commandLineArguments = String.Format(CommandlineStringFormat,
+										_nUnitPath,
+										String.Format("{0} /runlist=\\\"{1}\\\" /nologo /noshadow /result=\\\"{2}\\\"", dllPaths, _runListFile, _testResultsFile),
+										_openCoverResultsFile);
+			}
 
-            CreateRunListFile();
+			CreateRunListFile();
 		}
 
 		/// <summary>

--- a/OpenCover.UI/Views/SettingsControl.xaml.cs
+++ b/OpenCover.UI/Views/SettingsControl.xaml.cs
@@ -32,7 +32,11 @@ namespace OpenCover.UI.Views
 
         void SelectNunitExeEvent(object sender, System.EventArgs e)
         {
-            var dialog = new OpenFileDialog { Filter = "Nunit Executable (nunit-console*.exe)|nunit-console*.exe" };
+            var dialog = new OpenFileDialog
+            {
+                Filter = "Nunit 2.x Executable (nunit-console*.exe)|nunit-console*.exe"
+                      + "|Nunit 3.x Executable|nunit3-console.exe"
+            };
             if (dialog.ShowDialog() == true)
             {
                 _vm.NUnitExePath = dialog.FileName;


### PR DESCRIPTION
This adds support for NUnit 3.x. Tests are discovered by the existing opencover.ui-way.
The current release of NUnit 3.0.1 contains a bug affecting the assembly name in the output file.
There will be a bug fix in release 3.2. (nunit/nunit#1195). Until then the executed tests will not show up as executed in the opencover.ui test explorer. Nevertheless the coverage is displayed.