### PR TITLE
Extended NUnitDiscoverer to look for traits on base classes

### DIFF
--- a/OpenCover.UI.TestDiscoverer.TestResources/NUnit/TestFixtureWithInheritedTraitTestCase.cs
+++ b/OpenCover.UI.TestDiscoverer.TestResources/NUnit/TestFixtureWithInheritedTraitTestCase.cs
@@ -1,0 +1,17 @@
+﻿using NUnit.Framework;
+
+namespace OpenCover.UI.TestDiscoverer.TestResources.NUnit
+{
+    [Category("InheritedTrait")]
+    public class InheritedTraitBase
+    {
+    }
+
+    [TestFixture]
+    [Category("ClassTrait")]
+    public class TestFixtureWithInheritedTraitTestCase : InheritedTraitBase
+    {
+        [Test]
+        public void SomeTraitTestMethod() { }
+    }
+}

--- a/OpenCover.UI.TestDiscoverer.TestResources/OpenCover.UI.TestDiscoverer.TestResources.csproj
+++ b/OpenCover.UI.TestDiscoverer.TestResources/OpenCover.UI.TestDiscoverer.TestResources.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MSTest\RegularTestFixture.cs" />
+    <Compile Include="NUnit\TestFixtureWithInheritedTraitTestCase.cs" />
     <Compile Include="NUnit\TestFixtureWithoutExplicitTextFixtureAttribute.cs" />
     <Compile Include="NUnit\RegularTestFixture.cs" />
     <Compile Include="NUnit\TestFixtureWithNamedTestCase.cs" />

--- a/OpenCover.UI.TestDiscoverer.Tests/DiscovererTestsBase.cs
+++ b/OpenCover.UI.TestDiscoverer.Tests/DiscovererTestsBase.cs
@@ -9,7 +9,7 @@ namespace OpenCover.UI.TestDiscoverer.Tests
     [TestFixture]
     public abstract class DiscovererTestsBase
     {
-        protected void AssertDiscoveredMethod(Type testFixtureInAssemblyToDiscoverTestsIn, string expectedNameOfFirstTestMethod)
+        protected void AssertDiscoveredMethod(Type testFixtureInAssemblyToDiscoverTestsIn, string expectedNameOfFirstTestMethod, IEnumerable<string> expectedTraits)
         {
             // Arrange
             var discoverer = new Discoverer(new List<string> { testFixtureInAssemblyToDiscoverTestsIn.Assembly.Location });
@@ -25,6 +25,15 @@ namespace OpenCover.UI.TestDiscoverer.Tests
 
             var discoveredMethod = discoveredTest.TestMethods.FirstOrDefault(x => x.Name == expectedNameOfFirstTestMethod);
             discoveredMethod.Should().NotBeNull();
+
+            if (expectedTraits != null)
+            {
+                var discoveredTraits = discoveredTest.Traits;
+                foreach (var expectedTrait in expectedTraits)
+                {
+                    discoveredTraits.Contains(expectedTrait).Should().BeTrue();
+                }
+            }
         }
     }
 }

--- a/OpenCover.UI.TestDiscoverer.Tests/MSTest/MSTestDiscovererTests.cs
+++ b/OpenCover.UI.TestDiscoverer.Tests/MSTest/MSTestDiscovererTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using OpenCover.UI.TestDiscoverer.TestResources.MSTest;
 
@@ -7,10 +8,10 @@ namespace OpenCover.UI.TestDiscoverer.Tests.MSTest
     [TestFixture]
     public class MSTestDiscovererTests : DiscovererTestsBase
     {
-        [TestCase(typeof(RegularTestClass), "RegularTestMethod")]
-        public void Discover_Finds_Regular_Test_Fixture_And_Method(Type testFixtureInAssemblyToDiscoverTestsIn, string expectedNameOfFirstTestMethod)
+        [TestCase(typeof(RegularTestClass), "RegularTestMethod", null)]
+        public void Discover_Finds_Regular_Test_Fixture_And_Method(Type testFixtureInAssemblyToDiscoverTestsIn, string expectedNameOfFirstTestMethod, IEnumerable<string> expectedTraits)
         {
-            AssertDiscoveredMethod(testFixtureInAssemblyToDiscoverTestsIn, expectedNameOfFirstTestMethod);
+            AssertDiscoveredMethod(testFixtureInAssemblyToDiscoverTestsIn, expectedNameOfFirstTestMethod, expectedTraits);
         }
     }
 }

--- a/OpenCover.UI.TestDiscoverer.Tests/NUnit/NUnitDiscovererTests.cs
+++ b/OpenCover.UI.TestDiscoverer.Tests/NUnit/NUnitDiscovererTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using OpenCover.UI.TestDiscoverer.TestResources.NUnit;
 
@@ -6,13 +7,14 @@ namespace OpenCover.UI.TestDiscoverer.Tests.NUnit
 {
     public class NUnitDiscovererTests : DiscovererTestsBase
     {
-        [TestCase(typeof(RegularTestFixture), "RegularTestMethod")]
-        [TestCase(typeof(TestFixtureWithoutExplicitTestFixtureAttribute), "TestMethodInTestFixtureWithoutExplicitTestFixtureAttribute")]
-        [TestCase(typeof(TestFixtureWithTestCase), "SomeTestCase")]
-        [TestCase(typeof(TestFixtureWithNamedTestCase), "SomeNamedTestCase")]
-        public void Discover_Finds_Regular_Test_Fixture_And_Method(Type testFixtureInAssemblyToDiscoverTestsIn, string expectedNameOfFirstTestMethod)
+        [TestCase(typeof(RegularTestFixture), "RegularTestMethod", null)]
+        [TestCase(typeof(TestFixtureWithoutExplicitTestFixtureAttribute), "TestMethodInTestFixtureWithoutExplicitTestFixtureAttribute", null)]
+        [TestCase(typeof(TestFixtureWithTestCase), "SomeTestCase", null)]
+        [TestCase(typeof(TestFixtureWithNamedTestCase), "SomeNamedTestCase", null)]
+        [TestCase(typeof(TestFixtureWithInheritedTraitTestCase), "SomeTraitTestMethod", new string[] { "InheritedTrait", "ClassTrait" })]
+        public void Discover_Finds_Regular_Test_Fixture_And_Method(Type testFixtureInAssemblyToDiscoverTestsIn, string expectedNameOfFirstTestMethod, IEnumerable<string> expectedTraits)
         {
-            AssertDiscoveredMethod(testFixtureInAssemblyToDiscoverTestsIn, expectedNameOfFirstTestMethod);
+            AssertDiscoveredMethod(testFixtureInAssemblyToDiscoverTestsIn, expectedNameOfFirstTestMethod, expectedTraits);
         }
     }
 }

--- a/OpenCover.UI.TestDiscoverer/DiscovererBase.cs
+++ b/OpenCover.UI.TestDiscoverer/DiscovererBase.cs
@@ -90,18 +90,28 @@ namespace OpenCover.UI.TestDiscoverer
             return assembly;
         }
 
-        protected static void AddTraits(List<string> trait, CustomAttribute attribute, Type attributeType)
+        /// <summary>
+        /// Adds the traits.
+        /// </summary>
+        /// <param name="traits">The traits.</param>
+        /// <param name="attribute">The attribute.</param>
+        /// <param name="attributeType">Type of the attribute.</param>
+        protected static void AddTraits(List<string> traits, CustomAttribute attribute, Type attributeType)
         {
             if (attribute.AttributeType.FullName == attributeType.FullName)
             {
                 if (attribute.ConstructorArguments != null && attribute.ConstructorArguments.Count > 0)
                 {
-                    trait.Add(attribute.ConstructorArguments[0].Value.ToString());
+                    var trait = attribute.ConstructorArguments[0].Value.ToString();
+                    if (!traits.Contains(trait))
+                    {
+                        traits.Add(trait);
+                    }
                 }
             }
         }
-        
-                /// <summary>
+
+        /// <summary>
         /// Determines whether the assembly has a reference to the NUnit library.
         /// </summary>
         /// <param name="assembly">Assembly to check.</param>

--- a/OpenCover.UI.TestDiscoverer/NUnit/NUnitDiscoverer.cs
+++ b/OpenCover.UI.TestDiscoverer/NUnit/NUnitDiscoverer.cs
@@ -83,7 +83,7 @@ namespace OpenCover.UI.TestDiscoverer.NUnit
                         Name = type.Name,
                         Namespace = type.Namespace,
                         TestType = TestType.NUnit,
-                        Traits = traits.Count > 0 ? traits.ToArray() : null
+                        Traits = traits.ToArray()
                     };
 
                     TestClass.TestMethods = DiscoverTestsInClass(type, TestClass);
@@ -135,11 +135,7 @@ namespace OpenCover.UI.TestDiscoverer.NUnit
 			foreach (var method in type.Methods)
 			{
 				bool isTestMethod = false;
-                var traits = new List<string>();
-                if (@class.Traits != null && @class.Traits.Length > 0)
-                {
-                    traits.AddRange(@class.Traits);
-                }
+                var traits = @class.Traits.ToList();
 
 				try
 				{

--- a/OpenCover.UI/Model/Test/TestClass.cs
+++ b/OpenCover.UI/Model/Test/TestClass.cs
@@ -52,5 +52,11 @@ namespace OpenCover.UI.Model.Test
 		/// </summary>
 		[DataMember(Name = "tt")]
 		public TestType TestType { get; set; }
+
+		/// <summary>
+		/// Gets or sets the trait (TestCategory in MSTest, Category in NUnit)
+		/// </summary>
+		[DataMember(Name = "t")]
+		public string[] Traits { get; set; }
 	}
 }


### PR DESCRIPTION
This change walks up the inheritance tree of test classes and gathers all Category attributes so that you can specify a single [Category("")] on a base class and have all tests inherited from it get displayed under the same Trait in the OpenCover Test Explorer when grouping by Trait

[Category("Integration")]
public class IntegrationTestBase { }

[TestFixture]
public class Test1 : IntegrationTestBase { }

[TestFixture]
public class Test2 : IntegrationTestBase { }
   