### PR TITLE
Support for nested testclasses for MSTest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ packages
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/
 /OpenCover.UI.VS2013.sln.DotSettings
+OpenCover/

--- a/OpenCover.UI.TestDiscoverer.TestResources/MSTest/RegularTestFixture.cs
+++ b/OpenCover.UI.TestDiscoverer.TestResources/MSTest/RegularTestFixture.cs
@@ -9,5 +9,15 @@ namespace OpenCover.UI.TestDiscoverer.TestResources.MSTest
         public void RegularTestMethod()
         {
         }
+
+        [TestClass]
+        public class SubTestClass
+        {
+            [TestMethod]
+            public void RegularSubTestClassMethod()
+            {
+            }
+
+        }
     }
 }

--- a/OpenCover.UI.TestDiscoverer.TestResources/MSTest/RegularTestFixture.cs
+++ b/OpenCover.UI.TestDiscoverer.TestResources/MSTest/RegularTestFixture.cs
@@ -18,6 +18,15 @@ namespace OpenCover.UI.TestDiscoverer.TestResources.MSTest
             {
             }
 
+            [TestClass]
+            public class Sub2NdTestClass
+            {
+                [TestMethod]
+                public void RegularSub2NdTestClassMethod()
+                {
+                }
+
+            }
         }
     }
 }

--- a/OpenCover.UI.TestDiscoverer.Tests/MSTest/MSTestDiscovererTests.cs
+++ b/OpenCover.UI.TestDiscoverer.Tests/MSTest/MSTestDiscovererTests.cs
@@ -12,5 +12,11 @@ namespace OpenCover.UI.TestDiscoverer.Tests.MSTest
         {
             AssertDiscoveredMethod(testFixtureInAssemblyToDiscoverTestsIn, expectedNameOfFirstTestMethod);
         }
+
+        [TestCase(typeof(RegularTestClass.SubTestClass), "RegularSubTestClassMethod")]
+        public void Discover_Finds_Sub_Test_Fixture_And_Method(Type testFixtureInAssemblyToDiscoverTestsIn, string expectedNameOfFirstTestMethod)
+        {
+            AssertDiscoveredMethod(testFixtureInAssemblyToDiscoverTestsIn, expectedNameOfFirstTestMethod);
+        }
     }
 }

--- a/OpenCover.UI.TestDiscoverer.Tests/MSTest/MSTestDiscovererTests.cs
+++ b/OpenCover.UI.TestDiscoverer.Tests/MSTest/MSTestDiscovererTests.cs
@@ -18,5 +18,11 @@ namespace OpenCover.UI.TestDiscoverer.Tests.MSTest
         {
             AssertDiscoveredMethod(testFixtureInAssemblyToDiscoverTestsIn, expectedNameOfFirstTestMethod);
         }
+
+        [TestCase(typeof(RegularTestClass.SubTestClass.Sub2NdTestClass), "RegularSub2NdTestClassMethod")]
+        public void Discover_Finds_Sub2Nd_Test_Fixture_And_Method(Type testFixtureInAssemblyToDiscoverTestsIn, string expectedNameOfFirstTestMethod)
+        {
+            AssertDiscoveredMethod(testFixtureInAssemblyToDiscoverTestsIn, expectedNameOfFirstTestMethod);
+        }
     }
 }


### PR DESCRIPTION
Support written for nested test classes as per mentioned bug report #128, verified with an additional unit test. However only support for the MSTest discoverer and not yet for the NUnit discover as of now as I could not get NUnit to give results on my system yet via Opencover.UI